### PR TITLE
Update helpers.R

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -22,6 +22,7 @@ locate_download_link <- function(year = 2012,
 
   # get the link with the matching year
   link <- links[grepl(year,links)]
+  link <- link[!grepl("test",link)]
 
   # apply some cleaning opperations
   link <- gsub("href=\"", "", link)


### PR DESCRIPTION
Extend helper `locate_download_link ' to support ICE files by filtering out “test” subdirectories

The ICE directory at 
https://pubfs-rma.fpac.usda.gov/pub/References/insurance_control_elements/PASS/ includes “test” folders for each year, which should not be processed.   Add a filtering step to remove any links containing “test” so the helper  function works seamlessly with both ADM and ICE directories:
```r
link <- link[!grepl("test", link)]